### PR TITLE
Improve large purchase reimbursement form info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 CACHE
 venv/**
 v5env/**
+.prettierrc

--- a/forms/dcac/templates/dcac/includes/request-types-modal.html
+++ b/forms/dcac/templates/dcac/includes/request-types-modal.html
@@ -1,26 +1,46 @@
 <div class="modal fade" id="requestTypes" tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Request Types</h5>
-                <button type="button" class="close" data-dismiss="modal">
-                    <span>&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <p>
-                    There are three types of reimbursement requests: <br>
-                    <ul>
-                        <li><b>Standard Request</b></li>
-                        <li><b>Internal Transfer:</b> for requests to departments within Downing</li>
-                        <li><b>Large Request:</b> for purchases where societies are unable to directly make a purchase over £50. College will complete the purchase on your behalf, and deduct the given amount from your budget</li>
-                    </ul>
-                    The JCR wishes to ensure that the current reimbursement system for club and society funding does <b>not</b> put any students into financial difficulty, or prevent clubs and societies from being able to make larger purchases. <br><br>
-                    In cases where a purchase presents itself as a financial difficulty, you may select the 'Large' option and place a request (with all the necessary information) so that college can complete the purchase for your society using a college credit card. The given amount will then be deducted from your society/club budget. <br><br>
-                    Please note that making a standard request will likely mean that it will arrive quicker, and you can be sure of getting the exact item you want. This process creates extra work and takes longer, so we encourage you to <strong>only use the 'Large' option when needed</strong>.
-                    
-                </p>  
-            </div>
-        </div>
+  <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Request Types</h5>
+        <button type="button" class="close" data-dismiss="modal">
+          <span>&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>There are three types of reimbursement requests:</p>
+        <ul>
+          <li><b>Standard Request</b></li>
+          <li>
+            <b>Internal Transfer:</b>
+            for requests to departments within Downing
+          </li>
+          <li>
+            <b>Large Request:</b>
+            for purchases where societies are unable to directly make a purchase over £50. College will complete the
+            purchase on your behalf, and deduct the given amount from your budget
+          </li>
+        </ul>
+        <p>
+          The JCR wishes to ensure that the current reimbursement system for club and society funding does
+          <b>not</b>
+          put any students into financial difficulty, or prevent clubs and societies from being able to make larger
+          purchases.
+        </p>
+        <p>
+          For purchases that need to be made using the college credit card, please select the
+          <strong>‘Large’</strong>
+          option and submit a request with all the necessary information. The amount will then be deducted from your
+          society or club budget.
+        </p>
+        <p>
+          For all other purchases, please make a
+          <strong>standard request</strong>
+          instead. Invoices can be processed more quickly this way. Please enter the bank details shown on the invoice
+          instead of your own. Using the ‘Large’ option when it’s not required adds extra processing time and workload,
+          so please only select it when the college card is needed.
+        </p>
+      </div>
     </div>
+  </div>
 </div>


### PR DESCRIPTION
Rewrite the large purchase reimbursement on the website to clarify that the large purchase option is only required for purchases involving the college card, and invoices can be processed quicker by entering them as a standard request, with the bank details on the invoice entered in place of your own bank details.